### PR TITLE
Allow multiple T labels

### DIFF
--- a/ruled_labels/specs_cumulus.yaml
+++ b/ruled_labels/specs_cumulus.yaml
@@ -213,12 +213,12 @@ rules:
       when: !one_of [B1]
       require: !one_of [C*]
 
-  - name: Release mentions need a topic (T)
+  - name: Release mentions need one or more topic(s) (T)
     id: require_one_t_when_b1
     tags: [PR]
     spec:
       when: !one_of [B1]
-      require: !one_of [T*]
+      require: !some_of [T*]
 
   - name: One single issue status (S) label allowed
     id: single_s

--- a/ruled_labels/tests_cumulus.yaml
+++ b/ruled_labels/tests_cumulus.yaml
@@ -32,6 +32,18 @@ specs:
     labels: [ B1, D1 ]
     expected: false
 
+  - name: Pass - Release accept one T label
+    filter:
+      id: [ accept_one_t_when_b1 ]
+    labels: [ B1, D1, T1 ]
+    expected: true
+
+  - name: Pass - Release accept multiple T labels
+    filter:
+      id: [ accept_multiple_t_when_b1 ]
+    labels: [ B1, D1, T1, T2 ]
+    expected: true
+
   - name: Fail - Only one criticality label allowed
     filter:
       id: [ single_c ]


### PR DESCRIPTION
The previous rules allowed only ONE T label.
This PR relaxes the rule and allows multiple.
Tests have been added as well.

The origin of the change is [this issue](https://github.com/chevdor/ruled_labels/issues/11) where the user legitimately expects to be able to provide multiple `T` labels.