### PR TITLE
Accept `T2` by `B1` mention check

### DIFF
--- a/ruled_labels/specs_cumulus.yaml
+++ b/ruled_labels/specs_cumulus.yaml
@@ -216,12 +216,12 @@ rules:
       when: !one_of [B1]
       require: !one_of [C*]
 
-  - name: Release mentions need a topic "node" or "runtime"
-    id: require_t0_or_t1_when_b1
+  - name: Release mentions need a topic "node", "runtime" or "API"
+    id: require_t_when_b1
     tags: [PR]
     spec:
       when: !one_of [B1]
-      require: !one_of [T0, T1]
+      require: !one_of [T0, T1, T2]
 
   - name: Release mentions can have several topics
     id: allow_multiple_t_when_b1

--- a/ruled_labels/specs_polkadot.yaml
+++ b/ruled_labels/specs_polkadot.yaml
@@ -219,12 +219,12 @@ rules:
       when: !one_of [B1]
       require: !one_of [C*]
 
-  - name: Release mentions need a topic "node" or "runtime"
-    id: require_t0_or_t1_when_b1
+  - name: Release mentions need a topic "node", "runtime" or "API"
+    id: require_t_when_b1
     tags: [PR]
     spec:
       when: !one_of [B1]
-      require: !one_of [T0, T1]
+      require: !one_of [T0, T1, T2]
 
   - name: Release mentions can have several topics
     id: allow_multiple_t_when_b1

--- a/ruled_labels/tests_cumulus.yaml
+++ b/ruled_labels/tests_cumulus.yaml
@@ -34,20 +34,32 @@ specs:
 
   - name: Fail - Release need a topic.
     filter:
-      id: [ require_t0_or_t1_when_b1 ]
+      id: [ require_t_when_b1 ]
     labels: [ B1, D1 ]
     expected: false
 
-  - name: Pass - Release has a topic.
+  - name: Pass - Release has T0 as topic.
     filter:
-      id: [ require_t0_or_t1_when_b1 ]
+      id: [ require_t_when_b1 ]
     labels: [ B1, D1, T0 ]
+    expected: true
+
+  - name: Pass - Release has T1 as topic.
+    filter:
+      id: [ require_t_when_b1 ]
+    labels: [ B1, D1, T1 ]
+    expected: true
+
+  - name: Pass - Release has T2 as topic.
+    filter:
+      id: [ require_t_when_b1 ]
+    labels: [ B1, D1, T2 ]
     expected: true
 
   - name: Pass - PR has multiple topics
     filter:
       id: [ allow_multiple_t_when_b1 ]
-    labels: [ B1, T0, T7, D1 ]
+    labels: [ B1, T0, T2, T7, D1 ]
     expected: true
 
   - name: Fail - Only one criticality label allowed

--- a/ruled_labels/tests_polkadot.yaml
+++ b/ruled_labels/tests_polkadot.yaml
@@ -34,20 +34,32 @@ specs:
   
   - name: Fail - Release need a topic.
     filter:
-      id: [ require_t0_or_t1_when_b1 ]
+      id: [ require_t_when_b1 ]
     labels: [ B1, D1 ]
     expected: false
   
-  - name: Pass - Release has a topic.
+  - name: Pass - Release has T0 as topic.
     filter:
-      id: [ require_t0_or_t1_when_b1 ]
+      id: [ require_t_when_b1 ]
     labels: [ B1, D1, T0 ]
+    expected: true
+
+  - name: Pass - Release has T1 as topic.
+    filter:
+      id: [ require_t_when_b1 ]
+    labels: [ B1, D1, T1 ]
+    expected: true
+
+  - name: Pass - Release has T2 as topic.
+    filter:
+      id: [ require_t_when_b1 ]
+    labels: [ B1, D1, T2 ]
     expected: true
 
   - name: Pass - PR has multiple topics
     filter:
       id: [ allow_multiple_t_when_b1 ]
-    labels: [ B1, T0, T7, D1 ]
+    labels: [ B1, T0, T2, T7, D1 ]
     expected: true
 
   - name: Fail - Only one criticality label allowed


### PR DESCRIPTION
Changes to a runtime API need a `B1` label, but `B1` rejects `T2`.  Therefore:
- Accept the `T2` label when `B1` is specified

MR https://github.com/paritytech/polkadot/pull/6536 and https://github.com/paritytech/cumulus/pull/2073 suffer from this.  
TODO:  
- [ ] Add tests