### PR TITLE
Use a matrix for the repos

### DIFF
--- a/.github/workflows/check-label-rules.yaml
+++ b/.github/workflows/check-label-rules.yaml
@@ -6,6 +6,10 @@ on:
 jobs:
   check-label-rules:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: [cumulus, polkadot]
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -19,11 +23,10 @@ jobs:
           IMAGE: paritytech/ruled_labels:0.4.0
         run: docker pull $IMAGE
 
-      - name: Check label Rules
+      - name: Check label Rules for ${{ matrix.repo }}
         env:
           IMAGE: paritytech/ruled_labels:0.4.0
           MOUNT: /work
           RULES_PATH: ruled_labels
         run: |
-          docker run --rm -i -v $PWD/${RULES_PATH}/:$MOUNT $IMAGE test -s ${MOUNT}/specs_cumulus.yaml ${MOUNT}/tests_cumulus.yaml
-          docker run --rm -i -v $PWD/${RULES_PATH}/:$MOUNT $IMAGE test -s ${MOUNT}/specs_polkadot.yaml ${MOUNT}/tests_polkadot.yaml
+          docker run --rm -i -v $PWD/${RULES_PATH}/:$MOUNT $IMAGE test -s ${MOUNT}/specs_${{ matrix.repo }}.yaml ${MOUNT}/tests_${{ matrix.repo }}.yaml


### PR DESCRIPTION
That should speed up tests and make it simpler to add `substrate` and others in the future.