### PR TITLE
Disable for now the ability to have multiple T labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The repo contains specifications related to labels in the `polkadot`, `cumulus` and `substrate`.
 It uses [ruled_labels](https://github.com/paritytech/ruled_labels) to defined the rules about requirements and interactions between labels. The rules and tests are for all repos the same, only the labels differ for each repo.
- 
+
 
 If you need more information, check out the documentation:
 - [Labels Polkadot](./docs/doc_polkadot.md)

--- a/ruled_labels/specs_cumulus.yaml
+++ b/ruled_labels/specs_cumulus.yaml
@@ -258,12 +258,19 @@ rules:
       when: !one_of [B1]
       require: !one_of [T0, T1, T2]
 
-  - name: Release mentions can have several topics
-    id: allow_multiple_t_when_b1
+  # - name: Release mentions can have several topics
+  #   id: allow_multiple_t_when_b1
+  #   tags: [PR]
+  #   spec:
+  #     when: !one_of [B1]
+  #     require: !some_of [T*]
+
+  - name: Release mentions should have a single topic for now
+    id: allow_single_t_when_b1
     tags: [PR]
     spec:
       when: !one_of [B1]
-      require: !some_of [T*]
+      require: !one_of [T*]
 
   - name: One single issue status (S) label allowed
     id: single_s

--- a/ruled_labels/specs_polkadot.yaml
+++ b/ruled_labels/specs_polkadot.yaml
@@ -261,12 +261,19 @@ rules:
       when: !one_of [B1]
       require: !one_of [T0, T1, T2]
 
-  - name: Release mentions can have several topics
-    id: allow_multiple_t_when_b1
+  # - name: Release mentions can have several topics
+  #   id: allow_multiple_t_when_b1
+  #   tags: [PR]
+  #   spec:
+  #     when: !one_of [B1]
+  #     require: !some_of [T*]
+
+  - name: Release mentions should have a single topic for now
+    id: allow_single_t_when_b1
     tags: [PR]
     spec:
       when: !one_of [B1]
-      require: !some_of [T*]
+      require: !one_of [T*]
 
   - name: One single issue status (S) label allowed
     id: single_s

--- a/ruled_labels/specs_substrate.yaml
+++ b/ruled_labels/specs_substrate.yaml
@@ -259,12 +259,19 @@ rules:
       when: !one_of [B1]
       require: !one_of [T0, T1, T2]
 
-  - name: Release mentions can have several topics
-    id: allow_multiple_t_when_b1
+  # - name: Release mentions can have several topics
+  #   id: allow_multiple_t_when_b1
+  #   tags: [PR]
+  #   spec:
+  #     when: !one_of [B1]
+  #     require: !some_of [T*]
+
+  - name: Release mentions should have a single topic for now
+    id: allow_single_t_when_b1
     tags: [PR]
     spec:
       when: !one_of [B1]
-      require: !some_of [T*]
+      require: !one_of [T*]
 
   - name: One single issue status (S) label allowed
     id: single_s

--- a/ruled_labels/tests_cumulus.yaml
+++ b/ruled_labels/tests_cumulus.yaml
@@ -1,5 +1,5 @@
 name: Cumulus ruled-labels test cases
-spec_file: specs.yaml
+spec_file: specs_cumulus.yaml
 
 specs:
   - name: Pass - Pass all
@@ -14,7 +14,7 @@ specs:
     labels: [ A1 ]
     expected: false
 
-  - name: Pass - Release label provided.
+  - name: Pass - Release label provided
     filter:
       id: [ release_notes ]
     labels: [ A1, B0 ]
@@ -32,35 +32,41 @@ specs:
     labels: [ B1, T1, D1 ]
     expected: false
 
-  - name: Fail - Release need a topic.
+  - name: Fail - Release need a topic
     filter:
       id: [ require_t_when_b1 ]
     labels: [ B1, D1 ]
     expected: false
 
-  - name: Pass - Release has T0 as topic.
+  - name: Pass - Release has T0 as topic
     filter:
       id: [ require_t_when_b1 ]
     labels: [ B1, D1, T0 ]
     expected: true
 
-  - name: Pass - Release has T1 as topic.
+  - name: Pass - Release has T1 as topic
     filter:
       id: [ require_t_when_b1 ]
     labels: [ B1, D1, T1 ]
     expected: true
 
-  - name: Pass - Release has T2 as topic.
+  - name: Pass - Release has T2 as topic
     filter:
       id: [ require_t_when_b1 ]
     labels: [ B1, D1, T2 ]
     expected: true
 
-  - name: Pass - PR has multiple topics
+  # - name: Pass - PR has multiple topics.
+  #   filter:
+  #     id: [allow_multiple_t_when_b1]
+  #   labels: [B1, T0, T2, T7, D1]
+  #   expected: true
+
+  - name: FAIL FOR NOW - PR has multiple topics
     filter:
-      id: [ allow_multiple_t_when_b1 ]
-    labels: [ B1, T0, T2, T7, D1 ]
-    expected: true
+      id: [allow_single_t_when_b1]
+    labels: [B1, T0, T2, T7, D1]
+    expected: false
 
   - name: Fail - Only one criticality label allowed
     filter:

--- a/ruled_labels/tests_polkadot.yaml
+++ b/ruled_labels/tests_polkadot.yaml
@@ -1,5 +1,5 @@
 name: Polkadot ruled-labels test cases
-spec_file: specs.yaml
+spec_file: specs_polkadot.yaml
 
 specs:
   - name: Pass - Pass all
@@ -14,7 +14,7 @@ specs:
     labels: [ A1 ]
     expected: false
 
-  - name: Pass - Release label provided.
+  - name: Pass - Release label provided
     filter:
       id: [ release_notes ]
     labels: [ A1, B0 ]
@@ -31,36 +31,42 @@ specs:
       id: [ require_one_c_when_b1 ]
     labels: [ B1, T1, D1 ]
     expected: false
-  
+
   - name: Fail - Release need a topic.
     filter:
       id: [ require_t_when_b1 ]
     labels: [ B1, D1 ]
     expected: false
-  
-  - name: Pass - Release has T0 as topic.
+
+  - name: Pass - Release has T0 as topic
     filter:
       id: [ require_t_when_b1 ]
     labels: [ B1, D1, T0 ]
     expected: true
 
-  - name: Pass - Release has T1 as topic.
+  - name: Pass - Release has T1 as topic
     filter:
       id: [ require_t_when_b1 ]
     labels: [ B1, D1, T1 ]
     expected: true
 
-  - name: Pass - Release has T2 as topic.
+  - name: Pass - Release has T2 as topic
     filter:
       id: [ require_t_when_b1 ]
     labels: [ B1, D1, T2 ]
     expected: true
 
-  - name: Pass - PR has multiple topics
+  # - name: Pass - PR has multiple topics.
+  #   filter:
+  #     id: [allow_multiple_t_when_b1]
+  #   labels: [B1, T0, T2, T7, D1]
+  #   expected: true
+
+  - name: FAIL FOR NOW - PR has multiple topics
     filter:
-      id: [ allow_multiple_t_when_b1 ]
-    labels: [ B1, T0, T2, T7, D1 ]
-    expected: true
+      id: [allow_single_t_when_b1]
+    labels: [B1, T0, T2, T7, D1]
+    expected: false
 
   - name: Fail - Only one criticality label allowed
     filter:

--- a/ruled_labels/tests_substrate.yaml
+++ b/ruled_labels/tests_substrate.yaml
@@ -1,5 +1,5 @@
 name: Substrate ruled-labels test cases
-spec_file: specs.yaml
+spec_file: specs_substrate.yaml
 
 specs:
   - name: Pass - Pass all
@@ -32,37 +32,43 @@ specs:
     labels: [B1, T1, D1]
     expected: false
 
-  - name: Fail - Release needs a topic.
+  - name: Fail - Release needs a topic
     filter:
       id: [require_t0_or_t1_when_b1]
     labels: [B1, D1]
     expected: false
 
-  - name: Pass - Release has T0 as topic.
+  - name: Pass - Release has T0 as topic
     filter:
       id: [require_t0_or_t1_when_b1]
     labels: [B1, D1, T0]
     expected: true
 
-  - name: Pass - Release has T1 as topic.
+  - name: Pass - Release has T1 as topic
     filter:
       id: [require_t0_or_t1_when_b1]
     labels: [B1, D1, T1]
     expected: true
 
-  - name: Pass - Release has T2 as topic.
+  - name: Pass - Release has T2 as topic
     filter:
       id: [require_t0_or_t1_when_b1]
     labels: [B1, D1, T2]
     expected: true
 
-  - name: Pass - PR has multiple topics.
-    filter:
-      id: [allow_multiple_t_when_b1]
-    labels: [B1, T0, T2, T7, D1]
-    expected: true
+  # - name: Pass - PR has multiple topics
+  #   filter:
+  #     id: [allow_multiple_t_when_b1]
+  #   labels: [B1, T0, T2, T7, D1]
+  #   expected: true
 
-  - name: Fail - Only one criticality label allowed.
+  - name: FAIL FOR NOW - PR has multiple topics
+    filter:
+      id: [allow_single_t_when_b1]
+    labels: [B1, T0, T2, T7, D1]
+    expected: false
+
+  - name: Fail - Only one criticality label allowed
     filter:
       id: [single_c]
     labels: [B1, C1, C3]


### PR DESCRIPTION
There is currently an issue with some legacy tooling in the case of PRs with multiple T labels, only one T label will surface in the data fed to the templates.

This issue has been spotted in PRs with both T0 and T2 where only T2 reaches the templates.

This PR disables for now the ability to run into those case. Thise can be re-enabled later.

My question to @the-right-joyce and @ggwpez is whether we want to now add a new 3rd section to the release notes for T2(API). I am OK eitherway, the main question being whether we will have enough T2 PRs in each release to justify its own section.

We used to have only 2 sections:
- T0: node
- T1: runtime

If we want to keep it that way, the current [rules](https://github.com/paritytech/labels/blob/main/ruled_labels/specs_substrate.yaml#L255-L260) should be fixed.

If we want to keep a new 3rd T2 section, I would need to fix the templates to add it and the rules could stay as they are.