### PR TITLE
Separate T* and X*

### DIFF
--- a/ruled_labels/specs_cumulus.yaml
+++ b/ruled_labels/specs_cumulus.yaml
@@ -36,6 +36,9 @@ codes:
   - code: U
     name: Urgency
     description: In what time manner does this issue need to be resolved?
+  - code: X
+    name: Note-worthy labels
+    description: These labels determine in which section of the release-notes the PR will be shown.
 
 labels:
   - name: A0-please_review
@@ -191,34 +194,22 @@ labels:
   - name: S4-blocked
     description: Issue is blocked, see comments for further information
     color: 12238
-  - name: T0-node
-    description: This PR/Issue is related to the topic “node”
-    color: fbffe0
-  - name: T1-runtime
-    description: This PR/Issue is related to the topic “runtime”
-    color: F5FCE6
-  - name: T2-API
-    description: This PR/Issue is related to APIs
-    color: 009B40
-  - name: T3-relay_chain
+  - name: T0-relay_chain
     description: This PR/Issue is related to the Relay Chain
     color: ffeeee
-  - name: T4-smart_contracts
+  - name: T1-smart_contracts
     description: This PR/Issue is related to smart contracts
     color: 0C7BAD
-  - name: T5-parachains
+  - name: T2-parachains
     description: This PR/Issue is related to parachains
     color: 0052cc
-  - name: T6-XCM
-    description: This PR/Issue is related to XCM
-    color: d4c5f9
-  - name: T7-system_parachains
+  - name: T3-system_parachains
     description: This PR/Issue is related to System Parachains
     color: BFDADC
-  - name: T8-bridges
+  - name: T4-bridges
     description: This PR/Issue is related to bridges
     color: BFDADC
-  - name: T9-release
+  - name: T5-release
     description: This PR/Issue is related to topics touching the release notes
     color: 0052cc
   - name: U0-drop_everything
@@ -236,6 +227,18 @@ labels:
   - name: U4-some_day_maybe
     description: Issue might be worth doing eventually
     color: fffbed
+  - name: X0-node
+    description: This PR/Issue is related to the topic “node”
+    color: fbffe0
+  - name: X1-runtime
+    description: This PR/Issue is related to the topic “runtime”
+    color: F5FCE6
+  - name: X2-API
+    description: This PR/Issue is related to APIs
+    color: 009B40
+  - name: X3-XCM
+    description: This PR/Issue is related to XCM.
+    color: d4c5f9
 
 rules:
   - name: Require a single Release (B) label
@@ -252,25 +255,18 @@ rules:
       require: !one_of [C*]
 
   - name: Release mentions need a topic "node", "runtime" or "API"
-    id: require_t_when_b1
+    id: require_x_when_b1
     tags: [PR]
     spec:
       when: !one_of [B1]
-      require: !one_of [T0, T1, T2]
+      require: !one_of [X0, X1, X2]
 
-  # - name: Release mentions can have several topics
-  #   id: allow_multiple_t_when_b1
-  #   tags: [PR]
-  #   spec:
-  #     when: !one_of [B1]
-  #     require: !some_of [T*]
-
-  - name: Release mentions should have a single topic for now
-    id: allow_single_t_when_b1
-    tags: [PR]
+  - name: One single issue release topic (X) label allowed
+    id: single_x
+    tags:
     spec:
-      when: !one_of [B1]
-      require: !one_of [T*]
+      when: !some_of [X*]
+      require: !one_of [X*]
 
   - name: One single issue status (S) label allowed
     id: single_s

--- a/ruled_labels/specs_polkadot.yaml
+++ b/ruled_labels/specs_polkadot.yaml
@@ -36,6 +36,10 @@ codes:
   - code: U
     name: Urgency
     description: In what time manner does this issue need to be resolved?
+  - code: X
+    name: Note-worthy labels
+    description: These labels determine in which section of the release-notes the PR will be shown.
+
 
 labels:
   - name: A0-please_review
@@ -197,31 +201,19 @@ labels:
   - name: S5-on_ice
     description: Work is currently on hold, see comments for further information
     color: 122381
-  - name: T0-node
-    description: This PR/Issue is related to the topic “node”
-    color: fbffe0
-  - name: T1-runtime
-    description: This PR/Issue is related to the topic “runtime”
-    color: F5FCE6
-  - name: T2-API
-    description: This PR/Issue is related to APIs
-    color: 009B40
-  - name: T3-relay_chain
+  - name: T0-relay_chain
     description: This PR/Issue is related to the relay chain
     color: ffeeee
-  - name: T4-parachains_engineering
+  - name: T1-parachains_engineering
     description: This PR/Issue is related to Parachains performance, stability, maintenance
     color: 42F808
-  - name: T5-parachains_protocol
+  - name: T2-parachains_protocol
     description: This PR/Issue is related to Parachains features and protocol changes
     color: 14C663
-  - name: T6-XCM
-    description: This PR/Issue is related to XCM
-    color: c5def5
-  - name: T7-substrate
+  - name: T3-substrate
     description: This is an issue that needs to be implemented upstream in Substrate
     color: 1d76db
-  - name: T8-release
+  - name: T4-release
     description: This PR/Issue is related to topics touching the release notes
     color: 0052cc
   - name: U0-drop_everything
@@ -239,6 +231,18 @@ labels:
   - name: U4-some_day_maybe
     description: Issue might be worth doing eventually
     color: d2d1d3
+  - name: X0-node
+    description: This PR/Issue is related to the topic “node”
+    color: fbffe0
+  - name: X1-runtime
+    description: This PR/Issue is related to the topic “runtime”
+    color: F5FCE6
+  - name: X2-API
+    description: This PR/Issue is related to APIs
+    color: 009B40
+  - name: X3-XCM
+    description: This PR/Issue is related to XCM.
+    color: d4c5f9
 
 rules:
   - name: Require a single Release (B) label
@@ -255,25 +259,18 @@ rules:
       require: !one_of [C*]
 
   - name: Release mentions need a topic "node", "runtime" or "API"
-    id: require_t_when_b1
+    id: require_x_when_b1
     tags: [PR]
     spec:
       when: !one_of [B1]
-      require: !one_of [T0, T1, T2]
+      require: !one_of [X0, X1, X2]
 
-  # - name: Release mentions can have several topics
-  #   id: allow_multiple_t_when_b1
-  #   tags: [PR]
-  #   spec:
-  #     when: !one_of [B1]
-  #     require: !some_of [T*]
-
-  - name: Release mentions should have a single topic for now
-    id: allow_single_t_when_b1
-    tags: [PR]
+  - name: One single issue release topic (X) label allowed
+    id: single_x
+    tags:
     spec:
-      when: !one_of [B1]
-      require: !one_of [T*]
+      when: !some_of [X*]
+      require: !one_of [X*]
 
   - name: One single issue status (S) label allowed
     id: single_s

--- a/ruled_labels/specs_substrate.yaml
+++ b/ruled_labels/specs_substrate.yaml
@@ -37,6 +37,9 @@ codes:
   - code: U
     name: Urgency
     description: In what time manner does this issue need to be resolved?
+  - code: X
+    name: Note-worthy labels
+    description: These labels determine in which section of the release-notes the PR will be shown.
   - code: Z
     name: Contribution labels
     description: If you want to contribute to our project, here you will find issues of different levels of difficulty and mentored issues
@@ -195,34 +198,22 @@ labels:
   - name: S4-blocked
     description: "Issue is blocked, see comments for further information."
     color: "122381"
-  - name: T0-node
-    description: This PR/Issue is related to the topic “node”.
-    color: fbffe0
-  - name: T1-runtime
-    description: This PR/Issue is related to the topic “runtime”.
-    color: F5FCE6
-  - name: T2-API
-    description: This PR/Issue is related to APIs.
-    color: 009B40
-  - name: T3-relay_chain
+  - name: T0-relay_chain
     description: This PR/Issue is related to the Relay Chain.
     color: ffeeee
-  - name: T4-smart_contracts
+  - name: T1-smart_contracts
     description: This PR/Issue is related to smart contracts.
     color: 0C7BAD
-  - name: T5-parachains
+  - name: T2-parachains
     description: This PR/Issue is related to Parachains.
     color: 0052cc
-  - name: T6-XCM
-    description: This PR/Issue is related to XCM.
-    color: d4c5f9
-  - name: T7-system_parachains
+  - name: T3-system_parachains
     description: This PR/Issue is related to System Parachains.
     color: 86e62a
-  - name: T8-bridges
+  - name: T4-bridges
     description: This PR/Issue is related to bridges.
     color: BFDADC
-  - name: T9-release
+  - name: T5-release
     description: This PR/Issue is related to topics touching the release notes.
     color: 0052cc
   - name: U0-drop_everything
@@ -240,6 +231,18 @@ labels:
   - name: U4-some_day_maybe
     description: Issue might be worth doing eventually.
     color: fffbed
+  - name: X0-node
+    description: This PR/Issue is related to the topic “node”
+    color: fbffe0
+  - name: X1-runtime
+    description: This PR/Issue is related to the topic “runtime”
+    color: F5FCE6
+  - name: X2-API
+    description: This PR/Issue is related to APIs
+    color: 009B40
+  - name: X3-XCM
+    description: This PR/Issue is related to XCM.
+    color: d4c5f9
   - name: Z0-trivial
     description: Writing the issue is of the same difficulty as patching the code.
     color: ffffff
@@ -280,25 +283,18 @@ rules:
       require: !one_of [C*]
 
   - name: Release mentions need a topic "node", "runtime" or "API"
-    id: require_t0_or_t1_when_b1
+    id: require_x_when_b1
     tags: [PR]
     spec:
       when: !one_of [B1]
-      require: !one_of [T0, T1, T2]
-
-  # - name: Release mentions can have several topics
-  #   id: allow_multiple_t_when_b1
-  #   tags: [PR]
-  #   spec:
-  #     when: !one_of [B1]
-  #     require: !some_of [T*]
-
-  - name: Release mentions should have a single topic for now
-    id: allow_single_t_when_b1
-    tags: [PR]
+      require: !one_of [X0, X1, X2]
+  
+  - name: One single issue release topic (X) label allowed
+    id: single_x
+    tags:
     spec:
-      when: !one_of [B1]
-      require: !one_of [T*]
+      when: !some_of [X*]
+      require: !one_of [X*]
 
   - name: One single issue status (S) label allowed
     id: single_s

--- a/ruled_labels/tests_cumulus.yaml
+++ b/ruled_labels/tests_cumulus.yaml
@@ -34,38 +34,32 @@ specs:
 
   - name: Fail - Release need a topic
     filter:
-      id: [ require_t_when_b1 ]
+      id: [ require_x_when_b1 ]
     labels: [ B1, D1 ]
     expected: false
 
-  - name: Pass - Release has T0 as topic
+  - name: Pass - Release has X0 as topic
     filter:
-      id: [ require_t_when_b1 ]
-    labels: [ B1, D1, T0 ]
+      id: [ single_x ]
+    labels: [ B1, D1, X0 ]
     expected: true
 
-  - name: Pass - Release has T1 as topic
+  - name: Pass - Release has X1 as topic
     filter:
-      id: [ require_t_when_b1 ]
-    labels: [ B1, D1, T1 ]
+      id: [ single_x ]
+    labels: [ B1, D1, X1 ]
     expected: true
 
-  - name: Pass - Release has T2 as topic
+  - name: Pass - Release has X2 as topic
     filter:
-      id: [ require_t_when_b1 ]
-    labels: [ B1, D1, T2 ]
+      id: [ single_x ]
+    labels: [ B1, D1, X2 ]
     expected: true
 
-  # - name: Pass - PR has multiple topics.
-  #   filter:
-  #     id: [allow_multiple_t_when_b1]
-  #   labels: [B1, T0, T2, T7, D1]
-  #   expected: true
-
-  - name: FAIL FOR NOW - PR has multiple topics
+  - name: Fail - PR has multiple release topics
     filter:
-      id: [allow_single_t_when_b1]
-    labels: [B1, T0, T2, T7, D1]
+      id: [ single_x ]
+    labels: [B1, X0, X2, X1, D1]
     expected: false
 
   - name: Fail - Only one criticality label allowed

--- a/ruled_labels/tests_polkadot.yaml
+++ b/ruled_labels/tests_polkadot.yaml
@@ -32,40 +32,35 @@ specs:
     labels: [ B1, T1, D1 ]
     expected: false
 
-  - name: Fail - Release need a topic.
+  
+  - name: Fail - Release need a topic
     filter:
-      id: [ require_t_when_b1 ]
+      id: [ require_x_when_b1 ]
     labels: [ B1, D1 ]
     expected: false
 
-  - name: Pass - Release has T0 as topic
+  - name: Pass - Release has X0 as topic
     filter:
-      id: [ require_t_when_b1 ]
-    labels: [ B1, D1, T0 ]
+      id: [ single_x ]
+    labels: [ B1, D1, X0 ]
     expected: true
 
-  - name: Pass - Release has T1 as topic
+  - name: Pass - Release has X1 as topic
     filter:
-      id: [ require_t_when_b1 ]
-    labels: [ B1, D1, T1 ]
+      id: [ single_x ]
+    labels: [ B1, D1, X1 ]
     expected: true
 
-  - name: Pass - Release has T2 as topic
+  - name: Pass - Release has X2 as topic
     filter:
-      id: [ require_t_when_b1 ]
-    labels: [ B1, D1, T2 ]
+      id: [ single_x ]
+    labels: [ B1, D1, X2 ]
     expected: true
 
-  # - name: Pass - PR has multiple topics.
-  #   filter:
-  #     id: [allow_multiple_t_when_b1]
-  #   labels: [B1, T0, T2, T7, D1]
-  #   expected: true
-
-  - name: FAIL FOR NOW - PR has multiple topics
+  - name: Fail - PR has multiple release topics
     filter:
-      id: [allow_single_t_when_b1]
-    labels: [B1, T0, T2, T7, D1]
+      id: [ single_x ]
+    labels: [B1, X0, X2, X1, D1]
     expected: false
 
   - name: Fail - Only one criticality label allowed

--- a/ruled_labels/tests_substrate.yaml
+++ b/ruled_labels/tests_substrate.yaml
@@ -31,41 +31,35 @@ specs:
       id: [require_one_c_when_b1]
     labels: [B1, T1, D1]
     expected: false
-
-  - name: Fail - Release needs a topic
+ 
+  - name: Fail - Release need a topic
     filter:
-      id: [require_t0_or_t1_when_b1]
-    labels: [B1, D1]
+      id: [ require_x_when_b1 ]
+    labels: [ B1, D1 ]
     expected: false
 
-  - name: Pass - Release has T0 as topic
+  - name: Pass - Release has X0 as topic
     filter:
-      id: [require_t0_or_t1_when_b1]
-    labels: [B1, D1, T0]
+      id: [ single_x ]
+    labels: [ B1, D1, X0 ]
     expected: true
 
-  - name: Pass - Release has T1 as topic
+  - name: Pass - Release has X1 as topic
     filter:
-      id: [require_t0_or_t1_when_b1]
-    labels: [B1, D1, T1]
+      id: [ single_x ]
+    labels: [ B1, D1, X1 ]
     expected: true
 
-  - name: Pass - Release has T2 as topic
+  - name: Pass - Release has X2 as topic
     filter:
-      id: [require_t0_or_t1_when_b1]
-    labels: [B1, D1, T2]
+      id: [ single_x ]
+    labels: [ B1, D1, X2 ]
     expected: true
 
-  # - name: Pass - PR has multiple topics
-  #   filter:
-  #     id: [allow_multiple_t_when_b1]
-  #   labels: [B1, T0, T2, T7, D1]
-  #   expected: true
-
-  - name: FAIL FOR NOW - PR has multiple topics
+  - name: Fail - PR has multiple release topics
     filter:
-      id: [allow_single_t_when_b1]
-    labels: [B1, T0, T2, T7, D1]
+      id: [ single_x ]
+    labels: [B1, X0, X2, X1, D1]
     expected: false
 
   - name: Fail - Only one criticality label allowed


### PR DESCRIPTION
X* labels will now be release-related, so that multiple T* labels can be used
addresses #24 

@chevdor 
please change on the release script the `T0`, `T1`, `T2` and `T6` to `X0`, `X1`, `X2` and `X3`
