### PR TITLE
temporary R0 rule

### DIFF
--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -157,3 +157,10 @@ rules:
     spec:
       when: !some_of [D*]
       require: !one_of [D*]
+
+  - name: Enforce R0-silent
+    id: enforce_r0
+    tags:
+    spec:
+      when: !some_of [A1]
+      require: !all_of [R0]

--- a/ruled_labels/tests_polkadot-sdk.yaml
+++ b/ruled_labels/tests_polkadot-sdk.yaml
@@ -30,5 +30,16 @@ specs:
     filter:
       id: [ single_d ]
     labels: [ R0, D3, T10 ]
+    expected: true
+  
+  - name: Pass - A1 and R0
+    filter:
+      id: [ enforce_r0 ]
+    labels: [ A1, D3, R0 ]
+    expected: true
 
+  - name: Fail - R0 missing
+    filter:
+      id: [ enforce_r0 ]
+    labels: [ A1, T9, D2 ]
     expected: true

--- a/ruled_labels/tests_polkadot-sdk.yaml
+++ b/ruled_labels/tests_polkadot-sdk.yaml
@@ -42,4 +42,4 @@ specs:
     filter:
       id: [ enforce_r0 ]
     labels: [ A1, T9, D2 ]
-    expected: true
+    expected: false


### PR DESCRIPTION
as requested by @chevdor, for making sure that all `A1-insubstantial` PRs don't get mentioned in the release notes