### PR TITLE
Split gh-pages flow into check and deploy

### DIFF
--- a/.github/workflows/check-gh-pages.yaml
+++ b/.github/workflows/check-gh-pages.yaml
@@ -1,8 +1,6 @@
-name: Generate Label Documentation
+name: Check Label Documentation
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
   workflow_dispatch:
 
@@ -16,27 +14,19 @@ defaults:
   run:
     shell: bash
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
 
     env:
-      MDBOOK_VERSION: 0.4.21 # https://github.com/rust-lang/mdBook/releases
+      MDBOOK_VERSION: 0.4.37 # https://github.com/rust-lang/mdBook/releases
       TERA_VERSION: 0.2.4 # https://github.com/chevdor/tera-cli/release
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install Tools
         run: |
@@ -53,27 +43,12 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Render book
         run: ./scripts/generate_book.sh
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./docs/book
-
-  # Deployment job
-  deploy:
-    # this job will fail unless we are in the main branch
-    # so we skip the job for other branches such as PRs.
-    if: ${{ github.ref == 'refs/heads/main' }}
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -19,7 +19,6 @@ defaults:
 permissions:
   contents: read
   pages: write
-  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -1,0 +1,76 @@
+name: Deploy Label Documentation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      MDBOOK_VERSION: 0.4.37 # https://github.com/rust-lang/mdBook/releases
+      TERA_VERSION: 0.2.4 # https://github.com/chevdor/tera-cli/release
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0
+
+      - name: Install Tools
+        run: |
+          wget -O ${{ runner.temp }}/mdbook.tar.gz https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
+          tar xf ${{ runner.temp }}/mdbook.tar.gz && mv mdbook /usr/local/bin && \
+          wget -O ${{ runner.temp }}/tera.deb https://github.com/chevdor/tera-cli/releases/download/v${TERA_VERSION}/tera-cli_linux_amd64.deb && \
+          sudo dpkg -i ${{ runner.temp }}/tera.deb
+
+      - name: Generate the doc
+        run: ./scripts/build-doc.sh
+
+      - name: Check
+        run: ls -al ./docs/src
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      - name: Render book
+        run: ./scripts/generate_book.sh
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: ./docs/book
+
+  # Deployment job
+  deploy:
+    # this job will fail unless we are in the main branch
+    # so we skip the job for other branches such as PRs.
+    if: ${{ github.ref == 'refs/heads/main' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -18,6 +18,7 @@ defaults:
 permissions:
   contents: read
   pages: write
+  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -3,7 +3,6 @@ name: Deploy Label Documentation
 on:
   push:
     branches: [ main ]
-  pull_request:
 
 # Allow one concurrent deployment
 concurrency:


### PR DESCRIPTION
This PR splits existing github flow which builds and deploys the gh-pages into two separate flow:
- Check flow will be triggered on each PR request to check if the docs are building
- Deploy flow will be triggered only from the master branch to build and deploy it

Closes: https://github.com/paritytech/release-engineering/issues/203