### PR TITLE
Add T17-primitives label

### DIFF
--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -147,7 +147,7 @@ labels:
     description: Issues related to asynchronous backing.
     color: E97042
   - name: T17-runtime
-    description: Generic changes to runtime code.
+    description: Generic changes to runtime code that are not covered by any other label.
     color: 006b75
 
 rules:

--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -146,6 +146,9 @@ labels:
   - name: T16-async_backing
     description: Issues related to asynchronous backing.
     color: E97042
+  - name: T17-runtime
+    description: Generic changes to runtime code.
+    color: 006b75
 
 rules:
   - name: Require at least one topic

--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -146,8 +146,8 @@ labels:
   - name: T16-async_backing
     description: Issues related to asynchronous backing.
     color: E97042
-  - name: T17-runtime
-    description: Generic changes to runtime code that are not covered by any other label.
+  - name: T17-primitives
+    description: Changes to primitives that are not covered by any other label.
     color: 006b75
 
 rules:


### PR DESCRIPTION
We dont have a label just for general primitives code changes; sp-runtime etc. that are neither FRAME nor pallets or covered by other labels.  
Recent example: https://github.com/paritytech/polkadot-sdk/pull/3881  

I am proposing to add a label for generic primitives changes.