### PR TITLE
Add T18-zombienet_tests label

### DIFF
--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -152,6 +152,9 @@ labels:
   - name: T17-primitives
     description: Changes to primitives that are not covered by any other label.
     color: 006b75
+  - name: T18-zombienet_tests
+    description: Trigger zombienet CI tests.
+    color: E84D6D
 
 rules:
   - name: Require at least one topic


### PR DESCRIPTION
Zombienets are no longer automatically triggered with polkadot-sdk CI because of their flakiness (see [this](https://github.com/paritytech/polkadot-sdk/pull/8600))

This PR adds a label `T18-zombienet_tests`, which will allow triggering those tests if needed.
