### PR TITLE
Add `T19-skip-zombienet_tests` label

### DIFF
--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -158,6 +158,9 @@ labels:
   - name: T18-zombienet_tests
     description: Trigger zombienet CI tests.
     color: E84D6D
+  - name: T19-skip-zombienet_tests
+    description: Skip triggering of zombienet CI tests.
+    color: BAD28F
 
 rules:
   - name: Require at least one topic


### PR DESCRIPTION
This PR adds a label T19-skip-zombienet_tests, which will allow skipping zombienet CI tests.

We are about to re-enable automatic triggering of zombienet CI tests in `polkadot-sdk` repo - https://github.com/paritytech/polkadot-sdk/pull/8748.
This label will allow to skip them if something bad happens and zombienet CI tests stop working.