### PR TITLE
Make OG rust bounty description shorter than 100 characters

### DIFF
--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -48,7 +48,7 @@ labels:
     description: A task for a first time contributor to become familiar with the Polkadot-SDK.
     color: 7CB9E8
   - name: C3-og-rust-bounty
-    description: A task rewarded by the OG Rust bounty for successful completion. Read https://ogrust.com/ for more info and how to reach out.
+    description: A task rewarded by the OG Rust bounty for successful completion. See https://ogrust.com/
     color: e87cb9
   - name: D0-easy
     description: Can be fixed primarily by duplicating and adapting code by an intermediate coder.


### PR DESCRIPTION
Descriptions must be shorter than 100 chars