### PR TITLE
Add labels : T20-governance and T21-staking.

### DIFF
--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -165,7 +165,7 @@ labels:
     description: This PR/Issue is related to governance pallets (referenda, treasury, bounties).
     color: 8B5CF6
   - name: T21-staking
-    description: This PR/Issue is related to staking pallets.
+    description: This PR/Issue is related to staking pallets (staking, nomination-pools, election-provider, etc.).
     color: F59E0B
 
 rules:

--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -164,7 +164,9 @@ labels:
   - name: T20-governance
     description: This PR/Issue is related to governance pallets (referenda, treasury, bounties).
     color: 8B5CF6
-
+  - name: T21-staking
+    description: This PR/Issue is related to staking pallets.
+    color: F59E0B
 
 rules:
   - name: Require at least one topic

--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -161,6 +161,10 @@ labels:
   - name: T19-skip-zombienet_tests
     description: Skip triggering of zombienet CI tests.
     color: BAD28F
+  - name: T20-governance
+    description: This PR/Issue is related to governance pallets (referenda, treasury, bounties).
+    color: 8B5CF6
+
 
 rules:
   - name: Require at least one topic

--- a/ruled_labels/specs_polkadot-sdk.yaml
+++ b/ruled_labels/specs_polkadot-sdk.yaml
@@ -162,7 +162,7 @@ labels:
     description: Skip triggering of zombienet CI tests.
     color: BAD28F
   - name: T20-governance
-    description: This PR/Issue is related to governance pallets (referenda, treasury, bounties).
+    description: This PR/Issue is related to governance pallets (referenda, treasury, bounties, child-bounties, multi-asset-bounties).
     color: 8B5CF6
   - name: T21-staking
     description: This PR/Issue is related to staking pallets (staking, nomination-pools, election-provider, etc.).


### PR DESCRIPTION
## Summary

  - Add T20-governance label for governance-related pallets (referenda, treasury, bounties)
  - Add T21-staking label for staking-related pallets (staking, nomination-pools, election-provider, etc.)

##  Context

  Currently, governance and staking PRs/issues are tagged with the generic T2-pallets label. These new labels provide more granular topic categorization, making it easier to filter and track work in these areas. These labels are meant to be used  alongside T2-pallets, not as a replacement.